### PR TITLE
Don't write java.lang imports to generated classes

### DIFF
--- a/src/main/java/org/jboss/jdeparser/ArrayJType.java
+++ b/src/main/java/org/jboss/jdeparser/ArrayJType.java
@@ -64,6 +64,8 @@ class ArrayJType extends AbstractJType {
         return new NewUndimJArrayExpr(this);
     }
 
+    public String packageName() { return elementType.packageName(); }
+
     public String simpleName() {
         return elementType.simpleName();
     }

--- a/src/main/java/org/jboss/jdeparser/ImplJSources.java
+++ b/src/main/java/org/jboss/jdeparser/ImplJSources.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>

--- a/src/main/java/org/jboss/jdeparser/JSourceFile.java
+++ b/src/main/java/org/jboss/jdeparser/JSourceFile.java
@@ -18,6 +18,8 @@
 
 package org.jboss.jdeparser;
 
+import java.util.Set;
+
 /**
  * A source file.
  *
@@ -118,4 +120,18 @@ public interface JSourceFile extends JCommentable {
      * @return the annotation interface definition
      */
     JClassDef annotationInterface(int mods, String name);
+
+    /**
+     * Add set of classes that are implicitly imported by this source file.
+     *
+     * @param implicitImports {@link Set} of simple names
+     */
+    void addImplicitImports(Set<String> implicitImports);
+
+    /**
+     * Check whether given class is implicitly imported in this source file.
+     *
+     * @param simpleName simple name of the class
+     */
+    boolean hasImplicitImport(String simpleName);
 }

--- a/src/main/java/org/jboss/jdeparser/JSources.java
+++ b/src/main/java/org/jboss/jdeparser/JSources.java
@@ -19,6 +19,7 @@
 package org.jboss.jdeparser;
 
 import java.io.IOException;
+import java.util.Set;
 
 /**
  * A repository of source files.

--- a/src/main/java/org/jboss/jdeparser/JType.java
+++ b/src/main/java/org/jboss/jdeparser/JType.java
@@ -99,6 +99,8 @@ public interface JType {
      */
     String simpleName();
 
+    String packageName();
+
     /**
      * An expression of the form {@code ThisType.class}.
      *

--- a/src/main/java/org/jboss/jdeparser/NarrowedJType.java
+++ b/src/main/java/org/jboss/jdeparser/NarrowedJType.java
@@ -52,6 +52,8 @@ class NarrowedJType extends AbstractJType {
         return erased.simpleName();
     }
 
+    public String packageName() { return erased.packageName(); }
+
     public JExpr _class() {
         return erased._class();
     }

--- a/src/main/java/org/jboss/jdeparser/NestedJType.java
+++ b/src/main/java/org/jboss/jdeparser/NestedJType.java
@@ -91,6 +91,8 @@ class NestedJType extends AbstractJType {
         return name;
     }
 
+    public String packageName() { return enclosingType.packageName(); }
+
     public JType typeArg(final JType... args) {
         return new NarrowedJType(this, args);
     }

--- a/src/main/java/org/jboss/jdeparser/PrimitiveJType.java
+++ b/src/main/java/org/jboss/jdeparser/PrimitiveJType.java
@@ -27,12 +27,15 @@ import java.io.IOException;
  */
 class PrimitiveJType extends AbstractJType {
     private final String simpleName;
+
+    private final String packageName;
     private final ReferenceJType boxed;
     private StaticRefJExpr classExpr;
 
     PrimitiveJType(final String simpleName, final String boxed) {
         this.simpleName = simpleName;
         this.boxed = boxed == null ? null : new ReferenceJType("java.lang", boxed, this);
+        this.packageName = boxed == null ? null : "java.lang";
     }
 
     public JType box() {
@@ -73,6 +76,8 @@ class PrimitiveJType extends AbstractJType {
     public String simpleName() {
         return simpleName;
     }
+
+    public String packageName() { return packageName; }
 
     public String toString() {
         return simpleName;

--- a/src/main/java/org/jboss/jdeparser/ReferenceJType.java
+++ b/src/main/java/org/jboss/jdeparser/ReferenceJType.java
@@ -61,6 +61,10 @@ class ReferenceJType extends AbstractJType {
         return packageName + "." + simpleName;
     }
 
+    public String packageName() {
+        return packageName;
+    }
+
     public String simpleName() {
         return simpleName;
     }
@@ -108,7 +112,7 @@ class ReferenceJType extends AbstractJType {
         if (packageMatches && cf.hasImport(simpleName())) {
             // an explicit import masks the implicit import
             sourceFileWriter.writeClass(qualifiedName());
-        } else if (packageName.equals("java.lang") && ! sourceFileWriter.getClassFile().getSources().hasClass(currentPackageName + "." + simpleName()) || packageMatches) {
+        } else if (packageName.equals("java.lang") && ! sourceFileWriter.getClassFile().hasImplicitImport(simpleName()) || packageMatches) {
             // implicit import
             sourceFileWriter.writeClass(simpleName());
         } else if (cf.hasImport(this)) {

--- a/src/main/java/org/jboss/jdeparser/ThisJType.java
+++ b/src/main/java/org/jboss/jdeparser/ThisJType.java
@@ -36,6 +36,8 @@ class ThisJType extends AbstractJType {
         return 23;
     }
 
+    public String packageName() { return null; }
+
     public String simpleName() {
         return "<<THIS>>";
     }

--- a/src/main/java/org/jboss/jdeparser/WildcardJType.java
+++ b/src/main/java/org/jboss/jdeparser/WildcardJType.java
@@ -47,6 +47,8 @@ class WildcardJType extends AbstractJType {
         return targetType.hashCode() ^ (extendsNotSuper ? 0 : 1);
     }
 
+    public String packageName() { return targetType.packageName(); }
+
     public String simpleName() {
         return targetType.simpleName();
     }

--- a/src/test/java/org/jboss/jdeparser/SimpleExampleTestCase.java
+++ b/src/test/java/org/jboss/jdeparser/SimpleExampleTestCase.java
@@ -30,6 +30,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.math.BigDecimal;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
 


### PR DESCRIPTION
Can we make this change to avoid adding java.lang classes? Seems that new checkstyle versions have problems with that.